### PR TITLE
Add login/register test pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ python manage.py createsuperuser
 ```
 
 Then navigate to [http://localhost:8000/admin/](http://localhost:8000/admin/).
+
+## Test UI
+
+The `test_ui/` directory contains simple HTML pages for interacting with the
+API without a frontend framework. Open the files directly in your browser and
+ensure the backend is running.
+
+- `signup.html` – create a new account.
+- `login.html` – obtain an API token which is stored in `localStorage`.
+- `create-car.html` – create a car listing (requires login).
+- `my-cars.html` – view your car listings.

--- a/test_ui/create-car.html
+++ b/test_ui/create-car.html
@@ -2,9 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Create Car Listing</title>
+<title>Create Car Listing</title>
 </head>
 <body>
+  <header>
+    <nav>
+      <a href="create-car.html">Create Car</a> |
+      <span id="auth-links"></span>
+    </nav>
+  </header>
   <h1>Create a New Car Listing</h1>
   <form id="car-form">
     <label>Make: <input type="text" name="make" required /></label><br />
@@ -84,5 +90,6 @@
       }
     });
   </script>
+  <script src="header.js"></script>
 </body>
 </html>

--- a/test_ui/header.js
+++ b/test_ui/header.js
@@ -1,0 +1,18 @@
+function updateAuthLinks() {
+  const authLinks = document.getElementById('auth-links');
+  if (!authLinks) return;
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    authLinks.innerHTML = '<a href="my-cars.html">Your Cars</a> | <a href="#" id="logout-link">Logout</a>';
+    const logout = document.getElementById('logout-link');
+    logout.addEventListener('click', function(e) {
+      e.preventDefault();
+      localStorage.removeItem('access_token');
+      updateAuthLinks();
+    });
+  } else {
+    authLinks.innerHTML = '<a href="login.html">Login</a> | <a href="signup.html">Register</a>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', updateAuthLinks);

--- a/test_ui/login.html
+++ b/test_ui/login.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <header>
+    <nav id="auth-links"></nav>
+  </header>
+  <h1>Login</h1>
+  <form id="login-form">
+    <label>Username: <input type="text" name="username" required /></label><br />
+    <label>Password: <input type="password" name="password" required /></label><br />
+    <button type="submit">Login</button>
+  </form>
+  <p>No account? <a href="signup.html">Register</a></p>
+  <p id="login-error" style="color:red"></p>
+  <script src="header.js"></script>
+  <script>
+    document.getElementById('login-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(e.target);
+      const data = Object.fromEntries(formData.entries());
+      try {
+        const response = await fetch('http://localhost:8000/api/auth/login/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        const result = await response.json();
+        if (response.ok && result.key) {
+          localStorage.setItem('access_token', result.key);
+          window.location.href = 'my-cars.html';
+        } else {
+          document.getElementById('login-error').innerText = 'Login failed';
+        }
+      } catch (err) {
+        document.getElementById('login-error').innerText = 'Network error';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/test_ui/my-cars.html
+++ b/test_ui/my-cars.html
@@ -2,9 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>My Car Listings</title>
+<title>My Car Listings</title>
 </head>
 <body>
+  <header>
+    <nav>
+      <a href="create-car.html">Create Car</a> |
+      <span id="auth-links"></span>
+    </nav>
+  </header>
   <h1>Your Car Listings</h1>
   <ul id="car-list"></ul>
 
@@ -41,5 +47,6 @@
     // Call the function to load the cars
     loadMyCars();
   </script>
+  <script src="header.js"></script>
 </body>
 </html>

--- a/test_ui/signup.html
+++ b/test_ui/signup.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Register</title>
+</head>
+<body>
+  <header>
+    <nav id="auth-links"></nav>
+  </header>
+  <h1>Register</h1>
+  <form id="signup-form">
+    <label>Username: <input type="text" name="username" required /></label><br />
+    <label>Email: <input type="email" name="email" required /></label><br />
+    <label>Password: <input type="password" name="password1" required /></label><br />
+    <label>Confirm Password: <input type="password" name="password2" required /></label><br />
+    <button type="submit">Sign Up</button>
+  </form>
+  <p id="signup-error" style="color:red"></p>
+  <script src="header.js"></script>
+  <script>
+    document.getElementById('signup-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(e.target);
+      const data = Object.fromEntries(formData.entries());
+      try {
+        const response = await fetch('http://localhost:8000/api/auth/registration/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        const result = await response.json();
+        if (response.ok && result.key) {
+          localStorage.setItem('access_token', result.key);
+          window.location.href = 'my-cars.html';
+        } else {
+          document.getElementById('signup-error').innerText = 'Signup failed';
+        }
+      } catch (err) {
+        document.getElementById('signup-error').innerText = 'Network error';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML login and signup pages
- show user-specific links in a shared header script
- include the header in test UI pages
- document the test UI in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684707120fcc8331b50689097ca32d76