### PR TITLE
Fix auth flow and add static header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,9 @@ web/backend/static/
 **/public/worker-*.js.map
 
 static
+!backend/static/
 media
+!backend/static/header.js
 __pycache__
 
 # development database

--- a/backend/api/templates/create-car.html
+++ b/backend/api/templates/create-car.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -90,6 +91,6 @@
       }
     });
   </script>
-  <script src="header.js"></script>
+  <script src="{% static 'header.js' %}"></script>
 </body>
 </html>

--- a/backend/api/templates/home.html
+++ b/backend/api/templates/home.html
@@ -1,13 +1,31 @@
+{% load static %}
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title>Home</title>
+    <meta charset="UTF-8">
+    <title>Car Listings</title>
 </head>
 <body>
-{% if user.is_authenticated %}
-    <p>Welcome, {{ user.username }}! <a href="{% url 'logout' %}">Log out</a></p>
-{% else %}
-    <p>You are not logged in. <a href="{% url 'login' %}">Login</a> or <a href="{% url 'signup' %}">Sign up</a></p>
-{% endif %}
+  <header>
+    <nav id="auth-links"></nav>
+  </header>
+  <h1>All Car Listings</h1>
+  <ul id="car-list"></ul>
+
+  <script src="{% static 'header.js' %}"></script>
+  <script>
+    async function loadCars() {
+      const resp = await fetch('/api/cars/');
+      const cars = await resp.json();
+      const list = document.getElementById('car-list');
+      list.innerHTML = '';
+      cars.forEach(car => {
+        const li = document.createElement('li');
+        li.textContent = `${car.make} ${car.model} - $${car.price_per_day}/day`;
+        list.appendChild(li);
+      });
+    }
+    loadCars();
+  </script>
 </body>
 </html>

--- a/backend/api/templates/index.html
+++ b/backend/api/templates/index.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -63,6 +64,6 @@
     </div>
   </section>
 
-  <script src="header.js"></script>
+  <script src="{% static 'header.js' %}"></script>
 </body>
 </html>

--- a/backend/api/templates/login.html
+++ b/backend/api/templates/login.html
@@ -31,7 +31,8 @@
           body: JSON.stringify(data)
         });
         const result = await response.json();
-        if (response.ok) {
+        if (response.ok && result.key) {
+          localStorage.setItem('access_token', result.key);
           window.location.href = '{% url "home" %}';
         } else {
           document.getElementById('login-error').innerText = 'Login failed';

--- a/backend/api/templates/my-cars.html
+++ b/backend/api/templates/my-cars.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+{% load static %}
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -48,6 +49,6 @@
     // Call the function to load the cars
     loadMyCars();
   </script>
-  <script src="header.js"></script>
+  <script src="{% static 'header.js' %}"></script>
 </body>
 </html>

--- a/backend/api/templates/signup.html
+++ b/backend/api/templates/signup.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -18,7 +19,7 @@
     <button type="submit">Sign Up</button>
   </form>
   <p id="signup-error" style="color:red"></p>
-  <script src="header.js"></script>
+  <script src="{% static 'header.js' %}"></script>
   <script>
     document.getElementById('signup-form').addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -29,13 +30,12 @@
         const response = await fetch('http://localhost:8000/api/auth/registration/', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrf_token },
-          credentials: "include",
           body: JSON.stringify(data)
         });
         const result = await response.json();
         if (response.ok && result.key) {
           localStorage.setItem('access_token', result.key);
-          window.location.href = 'my-cars.html';
+          window.location.href = '{% url "home" %}';
         } else {
           document.getElementById('signup-error').innerText = 'Signup failed';
         }

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -58,6 +58,13 @@ def contact(request):
 class CarViewSet(viewsets.ModelViewSet):
     queryset = Car.objects.all()
 
+    def get_permissions(self):
+        if self.action in ["list", "retrieve"]:
+            permission_classes = [AllowAny]
+        else:
+            permission_classes = [IsAuthenticated]
+        return [permission() for permission in permission_classes]
+
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
 
@@ -66,7 +73,7 @@ class CarViewSet(viewsets.ModelViewSet):
         cars = self.queryset.filter(owner=request.user)
         serializer = self.get_serializer(cars, many=True)
         return Response(serializer.data)
-    
+
     def get_serializer_class(self):
         if self.action == "retrieve":
             return CarDetailSerializer

--- a/backend/static/header.js
+++ b/backend/static/header.js
@@ -1,0 +1,18 @@
+function updateAuthLinks() {
+  const authLinks = document.getElementById('auth-links');
+  if (!authLinks) return;
+  const token = localStorage.getItem('access_token');
+  if (token) {
+    authLinks.innerHTML = '<a href="/my-cars.html">Your Cars</a> | <a href="#" id="logout-link">Logout</a>';
+    const logout = document.getElementById('logout-link');
+    logout.addEventListener('click', function(e) {
+      e.preventDefault();
+      localStorage.removeItem('access_token');
+      updateAuthLinks();
+    });
+  } else {
+    authLinks.innerHTML = '<a href="/login/">Login</a> | <a href="/signup/">Register</a>';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', updateAuthLinks);


### PR DESCRIPTION
## Summary
- show car listings on the home page
- restore token-based login/signup logic
- allow anyone to view car listings
- serve a header JavaScript helper
- reference `header.js` from templates

## Testing
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851ada8dc2883318aa61df482c99ec7