### PR TITLE
Extend templates from base

### DIFF
--- a/backend/api/templates/create-car.html
+++ b/backend/api/templates/create-car.html
@@ -1,17 +1,9 @@
+{% extends 'base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-<title>Create Car Listing</title>
-</head>
-<body>
-  <header>
-    <nav>
-      <a href="create-car.html">Create Car</a> |
-      <span id="auth-links"></span>
-    </nav>
-  </header>
+
+{% block title %}Create Car Listing{% endblock %}
+
+{% block content %}
   <h1>Create a New Car Listing</h1>
   <form id="car-form">
     <label>Make: <input type="text" name="make" required /></label><br />
@@ -91,6 +83,4 @@
       }
     });
   </script>
-  <script src="{% static 'header.js' %}"></script>
-</body>
-</html>
+{% endblock %}

--- a/backend/api/templates/home.html
+++ b/backend/api/templates/home.html
@@ -1,18 +1,12 @@
+{% extends 'base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Car Listings</title>
-</head>
-<body>
-  <header>
-    <nav id="auth-links"></nav>
-  </header>
+
+{% block title %}Car Listings{% endblock %}
+
+{% block content %}
   <h1>All Car Listings</h1>
   <ul id="car-list"></ul>
 
-  <script src="{% static 'header.js' %}"></script>
   <script>
     async function loadCars() {
       const resp = await fetch('/api/cars/');
@@ -27,5 +21,4 @@
     }
     loadCars();
   </script>
-</body>
-</html>
+{% endblock %}

--- a/backend/api/templates/index.html
+++ b/backend/api/templates/index.html
@@ -1,9 +1,9 @@
+{% extends 'base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>CarBnB</title>
+
+{% block title %}CarBnB{% endblock %}
+
+{% block content %}
   <style>
     body { font-family: Arial, sans-serif; margin:0; padding:0; }
     header {
@@ -41,18 +41,14 @@
     }
     .hero-search input { padding:8px; margin:0 5px; }
   </style>
-</head>
-<body>
-  <header>
-    <div class="logo"><a href="index.html">CarBnB</a></div>
-    <div class="header-search">
+
+  <div class="logo"><a href="index.html">CarBnB</a></div>
+  <div class="header-search">
       <input type="text" placeholder="Where to?" />
       <input type="date" />
       <input type="date" />
       <button>Search</button>
-    </div>
-    <nav id="auth-links"></nav>
-  </header>
+  </div>
 
   <section class="hero">
     <h2>Find your next rental car</h2>
@@ -63,7 +59,4 @@
       <button>Search</button>
     </div>
   </section>
-
-  <script src="{% static 'header.js' %}"></script>
-</body>
-</html>
+{% endblock %}

--- a/backend/api/templates/login.html
+++ b/backend/api/templates/login.html
@@ -1,15 +1,9 @@
+{% extends 'base.html' %}
 {% load static %}
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Login</title>
-</head>
-<body>
-  <header>
-    <nav id="auth-links"></nav>
-  </header>
+{% block title %}Login{% endblock %}
+
+{% block content %}
   <h1>Login</h1>
   <form id="login-form" method="post" action="/login/">
     {% csrf_token %}
@@ -19,6 +13,4 @@
   </form>
   <p>No account? <a href="{% url 'signup' %}">Register</a></p>
   <p id="login-error" style="color:red"></p>
-  <script src="{% static 'header.js' %}"></script>
-</body>
-</html>
+{% endblock %}

--- a/backend/api/templates/my-cars.html
+++ b/backend/api/templates/my-cars.html
@@ -1,17 +1,9 @@
-<!DOCTYPE html>
+{% extends 'base.html' %}
 {% load static %}
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-<title>My Car Listings</title>
-</head>
-<body>
-  <header>
-    <nav>
-      <a href="create-car.html">Create Car</a> |
-      <span id="auth-links"></span>
-    </nav>
-  </header>
+
+{% block title %}My Car Listings{% endblock %}
+
+{% block content %}
   <h1>Your Car Listings</h1>
   <ul id="car-list"></ul>
 
@@ -49,6 +41,4 @@
     // Call the function to load the cars
     loadMyCars();
   </script>
-  <script src="{% static 'header.js' %}"></script>
-</body>
-</html>
+{% endblock %}

--- a/backend/api/templates/signup.html
+++ b/backend/api/templates/signup.html
@@ -1,14 +1,9 @@
+{% extends 'base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Register</title>
-</head>
-<body>
-  <header>
-    <nav id="auth-links"></nav>
-  </header>
+
+{% block title %}Register{% endblock %}
+
+{% block content %}
   <h1>Register</h1>
   <form id="signup-form">
     {% csrf_token %}
@@ -19,7 +14,6 @@
     <button type="submit">Sign Up</button>
   </form>
   <p id="signup-error" style="color:red"></p>
-  <script src="{% static 'header.js' %}"></script>
   <script>
     document.getElementById('signup-form').addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -44,5 +38,4 @@
       }
     });
   </script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- make home, login, signup, create-car, index and my-cars templates extend `base.html`
- remove standalone HTML structure from these pages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851ceabb00083318fa04f755235620f