### PR TITLE
Add Review API endpoints

### DIFF
--- a/backend/api/permissions.py
+++ b/backend/api/permissions.py
@@ -51,3 +51,14 @@ class CarImagePermission(permissions.BasePermission):
         return request.user.is_authenticated and (
             request.user.is_superuser or car_image.car.owner == request.user
         )
+
+
+class ReviewPermission(permissions.BasePermission):
+    """Only allow authors or superusers to modify reviews."""
+
+    def has_object_permission(self, request, view, review):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return request.user.is_authenticated and (
+            request.user.is_superuser or review.user == request.user
+        )

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -4,7 +4,7 @@ from dj_rest_auth.serializers import (
 from django.conf import settings
 from rest_framework import serializers
 
-from api.models import User, Car, Booking, CarImage
+from api.models import User, Car, Booking, CarImage, Review
 from api.utils import password_reset_url_generator
 
 
@@ -64,7 +64,7 @@ class CarDetailSerializer(serializers.ModelSerializer):
     owner = PublicUserSerializer(read_only = True)
     location = serializers.StringRelatedField()
     images = serializers.StringRelatedField(many=True)
-    reviews = serializers.StringRelatedField(many=True)
+    reviews = ReviewSerializer(many=True, read_only=True)
 
     class Meta:
             model = Car
@@ -88,3 +88,12 @@ class CarImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = CarImage
         fields = "__all__"
+
+
+class ReviewSerializer(serializers.ModelSerializer):
+    user = PublicUserSerializer(read_only=True)
+
+    class Meta:
+        model = Review
+        fields = "__all__"
+        read_only_fields = ["user", "car", "created_at"]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -13,8 +13,8 @@ from rest_framework.decorators import api_view, permission_classes, action
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from datetime import datetime
-from api.models import User, Car, Booking, CarImage
-from api.permissions import UserPermission, CarPermission, BookingPermission, CarImagePermission
+from api.models import User, Car, Booking, CarImage, Review
+from api.permissions import UserPermission, CarPermission, BookingPermission, CarImagePermission, ReviewPermission
 from api.serializers import (
     ContactFormSerializer,
     UserSerializer,
@@ -23,6 +23,7 @@ from api.serializers import (
     CarListSerializer,
     BookingSerializer,
     CarImageSerializer,
+    ReviewSerializer,
 )
 
 
@@ -261,3 +262,18 @@ class CarImageViewSet(viewsets.ModelViewSet):
         if car.owner != user and not user.is_superuser:
             raise PermissionError("You can only add images to your own cars.")
         serializer.save()
+
+
+class ReviewViewSet(viewsets.ModelViewSet):
+    queryset = Review.objects.all()
+    serializer_class = ReviewSerializer
+
+    def get_permissions(self):
+        if self.action in ["list", "retrieve"]:
+            permission_classes = [AllowAny]
+        else:
+            permission_classes = [IsAuthenticated, ReviewPermission]
+        return [permission() for permission in permission_classes]
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -11,6 +11,7 @@ from api.views import (
     UserViewSet,
     CarViewSet,
     CarImageViewSet,
+    ReviewViewSet,
     home,
     my_bookings,
     profile,
@@ -30,6 +31,7 @@ router.register(r"users", UserViewSet, basename="user")
 router.register("cars", CarViewSet, basename="car")
 router.register("bookings", BookingViewSet, basename="booking")
 router.register("car-images", CarImageViewSet, basename="car-image")
+router.register("reviews", ReviewViewSet, basename="review")
 
 urlpatterns = (
     [


### PR DESCRIPTION
## Summary
- enable Review model serialization and include reviews in `CarDetailSerializer`
- add Review viewset and routing
- ensure only authors or admins may modify reviews

## Testing
- `pytest -q`
- `python -m py_compile backend/api/serializers.py backend/api/views.py backend/core/urls.py backend/api/permissions.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b08b1868833195009faa23cd5b03